### PR TITLE
[BUG] Staticman error

### DIFF
--- a/staticman.yml
+++ b/staticman.yml
@@ -97,8 +97,8 @@ comments:
   # reCaptcha
   # Register your domain at https://www.google.com/recaptcha/ and choose reCAPTCHA V2
   reCaptcha:
-    enabled: true
-    siteKey: "6LdRBykTAAAAAFB46MnIu6ixuxwu9W1ihFF8G60Q"
+    enabled: false
+    siteKey: ""
     # Encrypt reCaptcha secret key using Staticman /encrypt endpoint
     # For more information, https://staticman.net/docs/encryption
-    secret: "PznnZGu3P6eTHRPLORniSq+J61YEf+A9zmColXDM5icqF49gbunH51B8+h+i2IvewpuxtA9TFoK68TuhUp/X3YKmmqhXasegHYabY50fqF9nJh9npWNhvITdkQHeaOqnFXUIwxfiEeUt49Yoa2waRR7a5LdRAP3SVM8hz0KIBT4="
+    secret: ""


### PR DESCRIPTION
:warning: Don't merge this!

It's just a way to raise an issue.

Hi my former bot <span>@</span>staticmanlab received your "invitation".  Sorry that I haven't updated what I might have said about Staticman in mmistakes.

# Steps to reproduce

1. Submit some sample data through your comment form.

    ![Screenshot from 2021-02-09 17-38-28](https://user-images.githubusercontent.com/5748535/107396157-cdfb4a00-6afd-11eb-9110-430168e7e0ff.png)

2. Observe the error.

```json
{
  "success":false,
  "rawError":{
    "name":"HttpError",
    "status":403,
    "headers":{
      "access-control-allow-origin":"*",
      "access-control-expose-headers":"ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, Deprecation, Sunset",
      "connection":"close",
      "content-encoding":"gzip",
      "content-security-policy":"default-src 'none'",
      "content-type":"application/json; charset=utf-8",
      "date":"Tue, 09 Feb 2021 16:32:53 GMT",
      "referrer-policy":"origin-when-cross-origin, strict-origin-when-cross-origin",
      "server":"GitHub.com",
      "strict-transport-security":"max-age=31536000; includeSubdomains; preload",
      "transfer-encoding":"chunked",
      "vary":"Accept-Encoding, Accept, X-Requested-With",
      "x-content-type-options":"nosniff",
      "x-frame-options":"deny",
      "x-github-media-type":"github.v3; format=json",
      "x-github-request-id":"D102:E73D:2885BFE:2CF00E0:6022B935",
      "x-ratelimit-limit":"60",
      "x-ratelimit-remaining":"51",
      "x-ratelimit-reset":"1612891417",
      "x-ratelimit-used":"9",
      "x-xss-protection":"1; mode=block"
    },
    "request":{
      "method":"GET",
      "url":"https://api.github.com/repos/mlsdpk/mlsdpk.github.io/contents/staticman.yml?ref=master",
      "headers":{
        "accept":"application/vnd.github.v3+json",
        "user-agent":"Staticman octokit.js/16.35.0 Node.js/14.5.0 (Linux 4.4; x64)",
        "authorization":"token [REDACTED]"
      },
      "request":{
        "timeout":5000,
        "validate":{
          "owner":{
            "required":true,
            "type":"string"
          },
          "path":{
            "required":true,
            "type":"string"
          },
          "ref":{
            "type":"string"
          },
          "repo":{
            "required":true,
            "type":"string"
          }
        }
      }
    },
    "documentation_url":"https://docs.github.com/rest",
    "_smErrorCode":"GITHUB_READING_FILE"
  },
  "errorCode":"GITHUB_READING_FILE"
}
```

# Analysis

Staticman's maintainer has recommended users to stay away from any public API instance in https://github.com/eduardoboucas/staticman/issues/317#issuecomment-565250060, in particular, `api dot staticman dot net`.  However, your site is still tempting to generate requests to the aforementioned API instance: in the screenshot, the target URL shown is `api dot staticman dot net/v2/...`.  This is caused by the theme's treatment of your empty `endpoint` site config variable.

https://github.com/mlsdpk/mlsdpk.github.io/blob/137b5d3bfd97d3499b410b5b5a3704b763a7384f/_config.yml#L33-L52
https://github.com/mlsdpk/mlsdpk.github.io/blob/137b5d3bfd97d3499b410b5b5a3704b763a7384f/_includes/comments.html#L38

Now it's recommended that every user set up his/her own API instance.  For a guide, you may see, for example,

1. https://hajekj.net/2020/04/15/staticman-setup-in-app-service/, which inspired my guides:
2. https://github.com/pacollins/hugo-future-imperfect-slim/wiki/staticman.yml with some screenshots of Heroku's dashboard for API server variables config

For my successful examples, you may see

1. my Jekyll MWE: https://github.com/VincentTam/TestStaticmanLab/pull/95
2. my test comment created for testing PR daattali/beautiful-jekyll<span>#</span>781: https://github.com/VincentTam/beautiful-jekyll/pull/35

From the empty lines of reCAPTCHA, it seems that you're not using it.

1. If you use reCAPTCHA, you need your own site key and secret in both `_config.yml` and root-level `staticman.yml`.
2. If you don't use reCAPTCHA, you need to set `recaptcha.enabled` to `false` in `staticman.yml`.